### PR TITLE
feat: Improve Alpaca calls

### DIFF
--- a/TradingBot/AlpacaClientExtensions.cs
+++ b/TradingBot/AlpacaClientExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System.Net;
+using System.Net.Sockets;
+using Alpaca.Markets;
+using TradingBot.Exceptions;
+using TradingBot.Exceptions.Alpaca;
+using ILogger = Serilog.ILogger;
+
+namespace TradingBot;
+
+public static class AlpacaClientExtensions
+{
+    public static async Task<T> ExecuteWithErrorHandling<T>(this Task<T> alpacaCall, ILogger? logger = null)
+    {
+        try
+        {
+            return await alpacaCall;
+        }
+        catch (RequestValidationException e)
+        {
+            logger?.Error(e, "Alpaca request failed validation");
+            throw new BadAlpacaRequestException(e);
+        }
+        catch (RestClientErrorException e) when (e.HttpStatusCode is { } statusCode)
+        {
+            logger?.Error(e, "Alpaca responded with {StatusCode}", statusCode);
+            throw new UnsuccessfulAlpacaResponseException(statusCode, e.ErrorCode, e.Message);
+        }
+        catch (Exception e) when (e is RestClientErrorException or HttpRequestException or SocketException
+                                      or TaskCanceledException)
+        {
+            logger?.Error(e, "Alpaca request failed");
+            throw new AlpacaCallFailedException(e);
+        }
+    }
+
+    public static async Task<T?> ReturnNullOnRequestLimit<T>(this Task<T> alpacaCall) where T : class
+    {
+        try
+        {
+            return await alpacaCall;
+        }
+        catch (RestClientErrorException e) when (e.HttpStatusCode == HttpStatusCode.TooManyRequests)
+        {
+            return null;
+        }
+    }
+}

--- a/TradingBot/AlpacaClientExtensions.cs
+++ b/TradingBot/AlpacaClientExtensions.cs
@@ -33,7 +33,8 @@ public static class AlpacaClientExtensions
         }
     }
 
-    public static async Task<T?> ReturnNullOnRequestLimit<T>(this Task<T> alpacaCall) where T : class
+    public static async Task<T?> ReturnNullOnRequestLimit<T>(this Task<T> alpacaCall, ILogger? logger = null)
+        where T : class
     {
         try
         {
@@ -41,6 +42,7 @@ public static class AlpacaClientExtensions
         }
         catch (RestClientErrorException e) when (e.HttpStatusCode == HttpStatusCode.TooManyRequests)
         {
+            logger?.Debug("Alpaca call failed because request limit was reached");
             return null;
         }
     }

--- a/TradingBot/Controllers/AssetsController.cs
+++ b/TradingBot/Controllers/AssetsController.cs
@@ -21,11 +21,15 @@ public class AssetsController : ControllerBase
     [HttpGet]
     [ProducesResponseType(typeof(AssetsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<AssetsResponse> GetAsync([FromQuery] bool mocked = false)
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<AssetsResponse>> GetAsync([FromQuery] bool mocked = false)
     {
         var assets = mocked
             ? await _assetsDataSource.GetMockedAssetsAsync(HttpContext.RequestAborted)
-            : await _assetsDataSource.GetAssetsAsync(HttpContext.RequestAborted);
-        return assets.ToResponse();
+            : await _assetsDataSource.GetLatestAssetsAsync(HttpContext.RequestAborted);
+
+        if (assets is not null) return assets.ToResponse();
+
+        return NotFound();
     }
 }

--- a/TradingBot/Controllers/ManualTestsController.cs
+++ b/TradingBot/Controllers/ManualTestsController.cs
@@ -125,6 +125,16 @@ public sealed class ManualTestsController : ControllerBase
         if (_memoryCache.GetCurrentStatistics() is { } stats) return stats;
         return NotFound();
     }
+
+    [HttpPost]
+    [Route("init-backtest-data")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<ActionResult> InitCacheAsync([FromQuery][Required] DateOnly start,
+        [FromQuery][Required] int symbols)
+    {
+        await _dataSource.InitializeBacktestDataAsync(start, DateOnly.FromDateTime(DateTime.Now).AddDays(-1), symbols);
+        return NoContent();
+    }
 }
 
 public sealed class TradingActionRequest : IValidatableObject

--- a/TradingBot/Program.cs
+++ b/TradingBot/Program.cs
@@ -177,5 +177,6 @@ public sealed class Program
         services.AddTransient<IAssetsStateQuery, AssetsStateQuery>();
 
         services.AddSingleton<IMarketDataCache, MarketDataCache>();
+        services.AddSingleton<IAlpacaCallQueue, AlpacaCallQueue>();
     }
 }

--- a/TradingBot/Services/ActionExecutor.cs
+++ b/TradingBot/Services/ActionExecutor.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Net.Sockets;
 using Alpaca.Markets;
 using TradingBot.Exceptions;
 using TradingBot.Exceptions.Alpaca;
@@ -34,7 +33,7 @@ public sealed class ActionExecutor : IActionExecutor
 
     public async Task ExecuteTradingActionsAsync(CancellationToken token = default)
     {
-        var actions = await _strategy.GetTradingActionsAsync();
+        var actions = await _strategy.GetTradingActionsAsync(token);
         foreach (var action in actions) await ExecuteActionAndHandleErrorsAsync(action, token);
     }
 
@@ -42,7 +41,8 @@ public sealed class ActionExecutor : IActionExecutor
     {
         _logger.Debug("Executing action {@Action}", action);
         using var client = await _clientFactory.CreateTradingClientAsync(token);
-        var order = await PostOrderAsync(CreateRequestForAction(action), client, token);
+        var order = await PostOrderAsync(CreateRequestForAction(action), client, token)
+            .ExecuteWithErrorHandling(_logger);
         await _tradingTask.SaveAndLinkSuccessfulActionAsync(action, order.OrderId, token);
     }
 
@@ -67,26 +67,10 @@ public sealed class ActionExecutor : IActionExecutor
         {
             return await client.PostOrderAsync(request, token);
         }
-        catch (RequestValidationException e)
-        {
-            _logger.Warning(e, "Alpaca request failed validation");
-            throw new BadAlpacaRequestException(e);
-        }
         catch (RestClientErrorException e) when (GetSpecialCaseException(e) is { } exception)
         {
             _logger.Warning(exception, "Alpaca request was invalid");
             throw exception;
-        }
-        catch (RestClientErrorException e) when (e.HttpStatusCode is { } statusCode)
-        {
-            _logger.Error(e, "Alpaca responded with {StatusCode}", statusCode);
-            throw new UnsuccessfulAlpacaResponseException(statusCode, e.ErrorCode, e.Message);
-        }
-        catch (Exception e) when (e is RestClientErrorException or HttpRequestException or SocketException
-                                      or TaskCanceledException)
-        {
-            _logger.Error(e, "Alpaca request failed");
-            throw new AlpacaCallFailedException(e);
         }
     }
 

--- a/TradingBot/Services/ActionExecutor.cs
+++ b/TradingBot/Services/ActionExecutor.cs
@@ -10,8 +10,7 @@ namespace TradingBot.Services;
 
 public interface IActionExecutor
 {
-    public Task ExecuteTradingActionsAsync(CancellationToken token = default);
-
+    Task ExecuteTradingActionsAsync(CancellationToken token = default);
     Task ExecuteActionAsync(TradingAction action, CancellationToken token = default);
 }
 

--- a/TradingBot/Services/AlpacaCallQueue.cs
+++ b/TradingBot/Services/AlpacaCallQueue.cs
@@ -1,0 +1,107 @@
+﻿using System.Net;
+using System.Threading.Channels;
+using Alpaca.Markets;
+using ILogger = Serilog.ILogger;
+
+namespace TradingBot.Services;
+
+public interface IAlpacaCallQueue
+{
+    Task<T> SendRequestWithRetriesAsync<T>(Func<Task<T>> request);
+}
+
+public sealed class AlpacaCallQueue : IAlpacaCallQueue, IAsyncDisposable
+{
+    private readonly ILogger _logger;
+    private readonly Channel<QueuedAlpacaCall> _queuedCalls = Channel.CreateUnbounded<QueuedAlpacaCall>();
+    private readonly Task _queueProcessingTask;
+    private bool _isOutOfRequests;
+
+    public AlpacaCallQueue(ILogger logger)
+    {
+        _logger = logger;
+        _queueProcessingTask = ProcessQueueAsync();
+    }
+
+    public async Task<T> SendRequestWithRetriesAsync<T>(Func<Task<T>> request)
+    {
+        if (_isOutOfRequests) return await QueueCallAsync(request);
+
+        try
+        {
+            return await request();
+        }
+        catch (RestClientErrorException e) when (e.HttpStatusCode == HttpStatusCode.TooManyRequests)
+        {
+            _isOutOfRequests = true;
+            return await QueueCallAsync(request);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _queuedCalls.Writer.Complete();
+        await _queueProcessingTask;
+    }
+
+    private async Task<T> QueueCallAsync<T>(Func<Task<T>> request)
+    {
+        var queued = new QueuedAlpacaCall<T>(request, new TaskCompletionSource<T>());
+        _queuedCalls.Writer.TryWrite(queued);
+        return await queued.TaskSource.Task;
+    }
+
+    private async Task ProcessQueueAsync()
+    {
+        try
+        {
+            while (await _queuedCalls.Reader.WaitToReadAsync())
+            {
+                var nextCall = await _queuedCalls.Reader.ReadAsync();
+                await RetryCallAsync(nextCall);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.Error(e, "An exception occured while processing queued Alpaca calls");
+            throw;
+        }
+    }
+
+    private async Task RetryCallAsync(QueuedAlpacaCall nextCall)
+    {
+        if (_isOutOfRequests) await Task.Delay(TimeSpan.FromSeconds(10));
+
+        if (await nextCall.RetryAsync())
+        {
+            _isOutOfRequests = false;
+            return;
+        }
+
+        _isOutOfRequests = true;
+        _queuedCalls.Writer.TryWrite(nextCall);
+    }
+
+    private abstract record QueuedAlpacaCall
+    {
+        public abstract Task<bool> RetryAsync();
+    }
+
+    private sealed record QueuedAlpacaCall<T>
+        (Func<Task<T>> Request, TaskCompletionSource<T> TaskSource) : QueuedAlpacaCall
+    {
+        public override async Task<bool> RetryAsync()
+        {
+            try
+            {
+                var response = await Request();
+                TaskSource.SetResult(response);
+                return true;
+            }
+            catch (RestClientErrorException e) when (e.HttpStatusCode == HttpStatusCode.TooManyRequests)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/TradingBot/Services/AlpacaCallQueue.cs
+++ b/TradingBot/Services/AlpacaCallQueue.cs
@@ -24,7 +24,7 @@ public sealed class AlpacaCallQueue : IAlpacaCallQueue, IAsyncDisposable
     internal AlpacaCallQueue(ILogger logger, Func<TimeSpan, Task> delay)
     {
         _delay = delay;
-        _logger = logger;
+        _logger = logger.ForContext<AlpacaCallQueue>();
         _queueProcessingTask = ProcessQueueAsync();
     }
 

--- a/TradingBot/Services/AssetsDataSource.cs
+++ b/TradingBot/Services/AssetsDataSource.cs
@@ -136,9 +136,9 @@ public sealed class AssetsDataSource : IAssetsDataSource
         _logger.Debug("Sending requests to Alpaca");
         using var client = await _clientFactory.CreateTradingClientAsync(token);
         var account = await _callQueue.SendRequestWithRetriesAsync(() =>
-            client.GetAccountAsync(token).ExecuteWithErrorHandling(_logger));
+            client.GetAccountAsync(token).ExecuteWithErrorHandling(_logger), _logger);
         var positions = await _callQueue.SendRequestWithRetriesAsync(() =>
-            client.ListPositionsAsync(token).ExecuteWithErrorHandling(_logger));
+            client.ListPositionsAsync(token).ExecuteWithErrorHandling(_logger), _logger);
         return new AlpacaResponses(account, positions);
     }
 

--- a/TradingBot/Services/AssetsStateCommand.cs
+++ b/TradingBot/Services/AssetsStateCommand.cs
@@ -30,7 +30,7 @@ public sealed class AssetsStateCommand : IAssetsStateCommand
     public async Task SaveCurrentAssetsAsync(CancellationToken token = default)
     {
         _logger.Debug("Saving current assets information");
-        var assets = await _assetsDataSource.GetAssetsAsync(token);
+        var assets = await _assetsDataSource.GetCurrentAssetsAsync(token);
 
         await using var context = await _dbContextFactory.CreateDbContextAsync(token);
         context.AssetsStates.Add(new AssetsState(assets, _clock.UtcNow).ToEntity());

--- a/TradingBot/Services/Strategy.cs
+++ b/TradingBot/Services/Strategy.cs
@@ -54,7 +54,7 @@ public sealed class Strategy : IStrategy
             var currentPrice = await GetCurrentPrice(symbol, token);
             closingPrices.Add(currentPrice);
 
-            closingPrices.AddRange(prediction.Value.Prices.Select(dailyPrice => dailyPrice.ClosingPrice).ToList());    
+            closingPrices.AddRange(prediction.Value.Prices.Select(dailyPrice => dailyPrice.ClosingPrice).ToList());
 
             if (IsPriceDecreasing(closingPrices, strategyParameters.MinDaysDecreasing) && assets.Positions.TryGetValue(symbol, out var position) && position.AvailableQuantity > 0)
             {
@@ -62,7 +62,7 @@ public sealed class Strategy : IStrategy
             }
             else if (IsPriceIncreasing(closingPrices, strategyParameters.MinDaysIncreasing))
             {
-                growthRates.Add(new AverageGrowthRate(symbol, CalculateAverageGrowthRate(closingPrices, strategyParameters.MinDaysIncreasing), 
+                growthRates.Add(new AverageGrowthRate(symbol, CalculateAverageGrowthRate(closingPrices, strategyParameters.MinDaysIncreasing),
                     CalculateBuyLimitPrice(prediction, currentPrice)));
             }
         }

--- a/TradingBot/Services/Strategy.cs
+++ b/TradingBot/Services/Strategy.cs
@@ -1,13 +1,6 @@
-using Microsoft.EntityFrameworkCore;
-using Alpaca.Markets;
-using TradingBot.Database;
-using TradingBot.Models;
 using Microsoft.AspNetCore.Authentication;
-using SQLitePCL;
-using TradingBot.Migrations;
-using Newtonsoft.Json.Linq;
 using TradingBot.Configuration;
-using System.Diagnostics;
+using TradingBot.Models;
 
 namespace TradingBot.Services;
 
@@ -24,7 +17,7 @@ public sealed class Strategy : IStrategy
     private readonly ISystemClock _clock;
     private readonly IStrategyParametersService _strategyParameters;
 
-    public Strategy(IPricePredictor predictor, IAssetsDataSource assetsDataSource, IMarketDataSource marketDataSource, 
+    public Strategy(IPricePredictor predictor, IAssetsDataSource assetsDataSource, IMarketDataSource marketDataSource,
         ISystemClock clock, IStrategyParametersService strategyParameters)
     {
         _predictor = predictor;
@@ -36,16 +29,17 @@ public sealed class Strategy : IStrategy
 
     public async Task<IReadOnlyList<TradingAction>> GetTradingActionsAsync(CancellationToken token = default)
     {
-        var strategyParameters = await _strategyParameters.GetConfigurationAsync();
+        var strategyParameters = await _strategyParameters.GetConfigurationAsync(token);
         var actions = await DetermineTradingActionsAsync(strategyParameters, token);
 
         return actions;
     }
 
-    private async Task<IReadOnlyList<TradingAction>> DetermineTradingActionsAsync(StrategyParametersConfiguration strategyParameters, CancellationToken token = default)
+    private async Task<IReadOnlyList<TradingAction>> DetermineTradingActionsAsync(
+        StrategyParametersConfiguration strategyParameters, CancellationToken token = default)
     {
-        var predictions = await _predictor.GetPredictionsAsync();
-        var assets = await _assetsDataSource.GetAssetsAsync();
+        var predictions = await _predictor.GetPredictionsAsync(token);
+        var assets = await _assetsDataSource.GetCurrentAssetsAsync(token);
         var tradingActions = new List<TradingAction>();
 
         var sellActions = new List<TradingAction>();
@@ -74,7 +68,8 @@ public sealed class Strategy : IStrategy
         }
 
         tradingActions.AddRange(sellActions);
-        tradingActions.AddRange(GetBuyActions(growthRates, cashAvailable, strategyParameters.MaxStocksBuyCount, strategyParameters.TopGrowingSymbolsBuyRatio));
+        tradingActions.AddRange(GetBuyActions(growthRates, cashAvailable, strategyParameters.MaxStocksBuyCount,
+            strategyParameters.TopGrowingSymbolsBuyRatio));
 
         return tradingActions;
     }
@@ -117,7 +112,8 @@ public sealed class Strategy : IStrategy
         return (closingPrices[minDaysIncreasing - 1] - closingPrices[0]) / closingPrices[0];
     }
 
-    private static decimal CalculateBuyLimitPrice(KeyValuePair<TradingSymbol, Prediction> prediction, decimal currentPrice)
+    private static decimal CalculateBuyLimitPrice(KeyValuePair<TradingSymbol, Prediction> prediction,
+        decimal currentPrice)
     {
         var nextDayLowPrice = prediction.Value.Prices.Select(dailyPrice => dailyPrice.LowPrice).ToList()[0];
         var buyLimitPrice = (currentPrice + nextDayLowPrice) / 2;
@@ -125,7 +121,8 @@ public sealed class Strategy : IStrategy
         return buyLimitPrice;
     }
 
-    private List<TradingAction> GetBuyActions(IReadOnlyList<AverageGrowthRate> growthRates, decimal cashAvaliable, int maxBuyCount, double topGrowingSymbolsBuyRatio)
+    private List<TradingAction> GetBuyActions(IReadOnlyList<AverageGrowthRate> growthRates, decimal cashAvailable,
+        int maxBuyCount, double topGrowingSymbolsBuyRatio)
     {
         var buyActions = new List<TradingAction>();
 
@@ -139,23 +136,24 @@ public sealed class Strategy : IStrategy
         {
             var symbol = topGrowingSymbols[i].Symbol;
             var price = topGrowingSymbols[i].Price;
-            if(price >= 1)
+            if (price >= 1)
                 price = Math.Round(price, 2);
             else
                 price = Math.Round(price, 4);
 
-            var quantity = (int)(cashAvaliable * (decimal)topGrowingSymbolsBuyRatio / price);
+            var quantity = (int)(cashAvailable * (decimal)topGrowingSymbolsBuyRatio / price);
 
             if (i == topGrowingSymbols.Count - 1)
-                quantity = (int)(cashAvaliable / price);
-            
+                quantity = (int)(cashAvailable / price);
+
             if (quantity <= 0)
                 continue;
 
-            cashAvaliable -= quantity * price;
+            cashAvailable -= quantity * price;
 
             buyActions.Add(TradingAction.LimitBuy(symbol, quantity, price, _clock.UtcNow));
         }
+
         return buyActions;
     }
 

--- a/TradingBot/Services/TradingActionQuery.cs
+++ b/TradingBot/Services/TradingActionQuery.cs
@@ -1,10 +1,8 @@
 ﻿using System.Diagnostics;
-using System.Net.Sockets;
 using Alpaca.Markets;
 using Microsoft.EntityFrameworkCore;
 using TradingBot.Database;
 using TradingBot.Database.Entities;
-using TradingBot.Exceptions;
 using TradingBot.Models;
 using ILogger = Serilog.ILogger;
 using OrderType = TradingBot.Models.OrderType;
@@ -119,32 +117,27 @@ public sealed class TradingActionQuery : ITradingActionQuery
 
         _logger.Verbose("Updating action {Id}: {Action}", entity.Id, entity);
 
-        try
+        var response = await client.GetOrderAsync(entity.AlpacaId.Value, token).ExecuteWithErrorHandling(_logger)
+            .ReturnNullOnRequestLimit();
+        if (response is null)
         {
-            var response = await client.GetOrderAsync(entity.AlpacaId.Value, token);
-            var executedAt = response.FilledAtUtc ??
-                             response.CancelledAtUtc ?? response.ExpiredAtUtc ?? response.FailedAtUtc;
+            _logger.Debug("Action {Id} was not updated because Alpaca request limit was hit", entity.Id);
+            return;
+        }
 
-            _logger.Verbose(
-                "Retrieved properties: Execution time = {ExecutionTime}, Status = {Status}, Fill price = {FillPrice}",
-                executedAt, response.OrderStatus.ToString(), response.AverageFillPrice);
+        var executedAt = response.FilledAtUtc
+                         ?? response.CancelledAtUtc
+                         ?? response.ExpiredAtUtc
+                         ?? response.FailedAtUtc;
 
-            entity.Status = response.OrderStatus;
-            entity.ExecutionTimestamp = executedAt is not null
-                ? new DateTimeOffset(executedAt.Value, TimeSpan.Zero).ToUnixTimeMilliseconds()
-                : null;
-            entity.AverageFillPrice = (double?)response.AverageFillPrice;
-        }
-        catch (RestClientErrorException e) when (e.HttpStatusCode is { } statusCode)
-        {
-            _logger.Error(e, "Alpaca responded with {StatusCode}", statusCode);
-            throw new UnsuccessfulAlpacaResponseException(statusCode, e.ErrorCode, e.Message);
-        }
-        catch (Exception e) when (e is RestClientErrorException or HttpRequestException or SocketException
-                                      or TaskCanceledException)
-        {
-            _logger.Error(e, "Alpaca request failed");
-            throw new AlpacaCallFailedException(e);
-        }
+        _logger.Verbose(
+            "Retrieved properties: Execution time = {ExecutionTime}, Status = {Status}, Fill price = {FillPrice}",
+            executedAt, response.OrderStatus.ToString(), response.AverageFillPrice);
+
+        entity.Status = response.OrderStatus;
+        entity.ExecutionTimestamp = executedAt is not null
+            ? new DateTimeOffset(executedAt.Value, TimeSpan.Zero).ToUnixTimeMilliseconds()
+            : null;
+        entity.AverageFillPrice = (double?)response.AverageFillPrice;
     }
 }

--- a/TradingBot/Services/TradingActionQuery.cs
+++ b/TradingBot/Services/TradingActionQuery.cs
@@ -117,8 +117,8 @@ public sealed class TradingActionQuery : ITradingActionQuery
 
         _logger.Verbose("Updating action {Id}: {Action}", entity.Id, entity);
 
-        var response = await client.GetOrderAsync(entity.AlpacaId.Value, token).ExecuteWithErrorHandling(_logger)
-            .ReturnNullOnRequestLimit();
+        var response = await client.GetOrderAsync(entity.AlpacaId.Value, token).ReturnNullOnRequestLimit(_logger)
+            .ExecuteWithErrorHandling(_logger);
         if (response is null)
         {
             _logger.Debug("Action {Id} was not updated because Alpaca request limit was hit", entity.Id);

--- a/TradingBotTests/ActionExecutorTests.cs
+++ b/TradingBotTests/ActionExecutorTests.cs
@@ -31,7 +31,8 @@ public sealed class ActionExecutorTests
         _strategy = Substitute.For<IStrategy>();
         _tradingTask = Substitute.For<ITradingTaskDetailsUpdater>();
         var logger = Substitute.For<ILogger>();
-        _executor = new ActionExecutor(_strategy, clientFactory, logger, _tradingTask);
+        var callQueue = new CallQueueMock();
+        _executor = new ActionExecutor(_strategy, clientFactory, logger, _tradingTask, callQueue);
     }
 
     [Fact]
@@ -62,8 +63,10 @@ public sealed class ActionExecutorTests
             order.Duration == TimeInForce.Day &&
             order.LimitPrice == null
         ), Arg.Any<CancellationToken>());
-        await _tradingTask.Received(1).SaveAndLinkSuccessfulActionAsync(actions[0], _actionId, Arg.Any<CancellationToken>());
-        await _tradingTask.Received(1).SaveAndLinkSuccessfulActionAsync(actions[1], _actionId, Arg.Any<CancellationToken>());
+        await _tradingTask.Received(1)
+            .SaveAndLinkSuccessfulActionAsync(actions[0], _actionId, Arg.Any<CancellationToken>());
+        await _tradingTask.Received(1)
+            .SaveAndLinkSuccessfulActionAsync(actions[1], _actionId, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/TradingBotTests/AlpacaCallQueueTests.cs
+++ b/TradingBotTests/AlpacaCallQueueTests.cs
@@ -1,0 +1,123 @@
+﻿using System.Net;
+using System.Reflection;
+using Alpaca.Markets;
+using FluentAssertions;
+using NSubstitute;
+using Serilog;
+using TradingBot.Services;
+
+namespace TradingBotTests;
+
+[Trait("Category", "Unit")]
+public sealed class AlpacaCallQueueTests : IAsyncDisposable
+{
+    private readonly AlpacaCallQueue _callQueue;
+    private readonly DelaySource _delay = new();
+
+    public AlpacaCallQueueTests()
+    {
+        var logger = Substitute.For<ILogger>();
+        _callQueue = new AlpacaCallQueue(logger, _delay.GetDelay);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _callQueue.DisposeAsync();
+    }
+
+    [Fact]
+    public void ShouldNotEnqueueCallIfItImmediatelySucceeds()
+    {
+        var result = _callQueue.SendRequestWithRetriesAsync(() => Task.FromResult(new Response()));
+        result.IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ShouldEnqueueCallIfItFailsAndRetryAfterDelay()
+    {
+        var responseSequence = new ResponseSequence(Task.FromException<Response>(TooManyRequests()),
+            Task.FromResult(new Response()));
+        var result = _callQueue.SendRequestWithRetriesAsync(responseSequence.GetNext);
+
+        await result.Awaiting(r => r.WaitAsync(TimeSpan.FromMilliseconds(10))).Should().ThrowAsync<TimeoutException>();
+
+        _delay.Advance();
+
+        await result.Awaiting(r => r.WaitAsync(TimeSpan.FromMilliseconds(10))).Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task ShouldReturnCallToQueueIfRetryFails()
+    {
+        var responseSequence = new ResponseSequence(Task.FromException<Response>(TooManyRequests()),
+            Task.FromException<Response>(TooManyRequests()), Task.FromResult(new Response()));
+        var result = _callQueue.SendRequestWithRetriesAsync(responseSequence.GetNext);
+
+        await result.Awaiting(r => r.WaitAsync(TimeSpan.FromMilliseconds(10))).Should().ThrowAsync<TimeoutException>();
+
+        _delay.Advance();
+
+        await result.Awaiting(r => r.WaitAsync(TimeSpan.FromMilliseconds(10))).Should().ThrowAsync<TimeoutException>();
+
+        _delay.Advance();
+
+        await result.Awaiting(r => r.WaitAsync(TimeSpan.FromMilliseconds(10))).Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task ShouldNotTryToImmediatelyExecuteCallIfPreviousFailed()
+    {
+        var responseSequence = new ResponseSequence(Task.FromException<Response>(TooManyRequests()),
+            Task.FromResult(new Response()));
+        var firstResult = _callQueue.SendRequestWithRetriesAsync(responseSequence.GetNext);
+        var secondResult = _callQueue.SendRequestWithRetriesAsync(() => Task.FromResult(new Response()));
+
+        await firstResult.Awaiting(r => r.WaitAsync(TimeSpan.FromMilliseconds(10))).Should()
+            .ThrowAsync<TimeoutException>();
+        await secondResult.Awaiting(r => r.WaitAsync(TimeSpan.FromMilliseconds(10))).Should()
+            .ThrowAsync<TimeoutException>();
+
+        _delay.Advance();
+
+        await firstResult.Awaiting(r => r.WaitAsync(TimeSpan.FromMilliseconds(10))).Should().NotThrowAsync();
+        await secondResult.Awaiting(r => r.WaitAsync(TimeSpan.FromMilliseconds(10))).Should().NotThrowAsync();
+    }
+
+    private static RestClientErrorException TooManyRequests()
+    {
+        return (RestClientErrorException)Activator.CreateInstance(typeof(RestClientErrorException),
+            BindingFlags.NonPublic | BindingFlags.Instance, null,
+            new object[] { new HttpResponseMessage(HttpStatusCode.TooManyRequests) }, null)!;
+    }
+
+    private sealed record ResponseSequence(params Task<Response>[] Responses)
+    {
+        private int _next;
+
+        public Task<Response> GetNext()
+        {
+            return Responses[_next == Responses.Length - 1 ? _next : _next++];
+        }
+    }
+
+    private sealed class DelaySource
+    {
+        private readonly List<TaskCompletionSource> _taskSources = new();
+
+        public Task GetDelay(TimeSpan timeSpan)
+        {
+            var taskSource = new TaskCompletionSource();
+            _taskSources.Add(taskSource);
+            return taskSource.Task;
+        }
+
+        public void Advance()
+        {
+            var sources = _taskSources.ToList();
+            _taskSources.Clear();
+            sources.ForEach(source => source.SetResult());
+        }
+    }
+
+    private sealed record Response;
+}

--- a/TradingBotTests/CallQueueMock.cs
+++ b/TradingBotTests/CallQueueMock.cs
@@ -1,10 +1,11 @@
-﻿using TradingBot.Services;
+﻿using Serilog;
+using TradingBot.Services;
 
 namespace TradingBotTests;
 
 public sealed class CallQueueMock : IAlpacaCallQueue
 {
-    public Task<T> SendRequestWithRetriesAsync<T>(Func<Task<T>> request) where T : class
+    public Task<T> SendRequestWithRetriesAsync<T>(Func<Task<T>> request, ILogger? logger = null) where T : class
     {
         return request();
     }

--- a/TradingBotTests/CallQueueMock.cs
+++ b/TradingBotTests/CallQueueMock.cs
@@ -1,0 +1,11 @@
+﻿using TradingBot.Services;
+
+namespace TradingBotTests;
+
+public sealed class CallQueueMock : IAlpacaCallQueue
+{
+    public Task<T> SendRequestWithRetriesAsync<T>(Func<Task<T>> request) where T : class
+    {
+        return request();
+    }
+}

--- a/TradingBotTests/ExchangeCalendarTests.cs
+++ b/TradingBotTests/ExchangeCalendarTests.cs
@@ -25,8 +25,8 @@ public sealed class ExchangeCalendarTests
         clientFactory.CreateTradingClientAsync(Arg.Any<CancellationToken>()).Returns(_tradingClient);
 
         var logger = Substitute.For<ILogger>();
-
-        _calendar = new ExchangeCalendar(clock, clientFactory, logger);
+        var callQueue = new CallQueueMock();
+        _calendar = new ExchangeCalendar(clock, clientFactory, logger, callQueue);
     }
 
     [Fact]

--- a/TradingBotTests/MarketDataSourceTests.cs
+++ b/TradingBotTests/MarketDataSourceTests.cs
@@ -28,7 +28,8 @@ public sealed class MarketDataSourceTests
 
         _assetsDataSource = Substitute.For<IAssetsDataSource>();
         var logger = Substitute.For<ILogger>();
-        _marketDataSource = new MarketDataSource(clientFactory, _assetsDataSource, logger, _marketDataCache);
+        var callQueue = new CallQueueMock();
+        _marketDataSource = new MarketDataSource(clientFactory, _assetsDataSource, logger, _marketDataCache, callQueue);
     }
 
     [Fact]
@@ -196,7 +197,7 @@ public sealed class MarketDataSourceTests
 
         _dataClient.ListMostActiveStocksByVolumeAsync(100, Arg.Any<CancellationToken>()).Returns(activeStocksResponse);
 
-        _assetsDataSource.GetAssetsAsync().Returns(new Assets
+        _assetsDataSource.GetCurrentAssetsAsync().Returns(new Assets
         {
             Cash = new Cash
             {

--- a/TradingBotTests/MarketDataSourceTests.cs
+++ b/TradingBotTests/MarketDataSourceTests.cs
@@ -67,7 +67,7 @@ public sealed class MarketDataSourceTests
 
         _marketDataCache.Received(1).CacheValidSymbols(Arg.Is<IReadOnlyList<TradingSymbol>>(symbols =>
             symbols.Contains(new TradingSymbol("TKN1")) && symbols.Contains(new TradingSymbol("TKN2")) &&
-            symbols.Contains(new TradingSymbol("TKN4"))));
+            symbols.Contains(new TradingSymbol("TKN4")) && symbols.Contains(new TradingSymbol("TKN5"))));
 
         _marketDataCache.Received(1).CacheDailySymbolData(new TradingSymbol("TKN1"),
             Arg.Any<IReadOnlyList<DailyTradingData>>(), DateOnly.MinValue, DateOnly.MaxValue);
@@ -193,7 +193,7 @@ public sealed class MarketDataSourceTests
 
         var activeStocksResponse = new[] { Substitute.For<IActiveStock>(), Substitute.For<IActiveStock>() };
         activeStocksResponse[0].Symbol.Returns("TKN1");
-        activeStocksResponse[1].Symbol.Returns("TKN4");
+        activeStocksResponse[1].Symbol.Returns("TKN5");
 
         _dataClient.ListMostActiveStocksByVolumeAsync(100, Arg.Any<CancellationToken>()).Returns(activeStocksResponse);
 

--- a/TradingBotTests/StrategyTests.cs
+++ b/TradingBotTests/StrategyTests.cs
@@ -234,7 +234,7 @@ namespace TradingBotTests
             predictior.GetPredictionsAsync().Returns(_predictions);
 
             var assetsData = Substitute.For<IAssetsDataSource>();
-            assetsData.GetAssetsAsync().Returns(_assets);
+            assetsData.GetCurrentAssetsAsync().Returns(_assets);
 
             var PLUGCurrentPrice = 4.1417857989668846092m;
             var SOXSCurrentPrice = 8.84562028538435697771m;


### PR DESCRIPTION
- `429 Too Many Requests` handling (we have 200 calls/minute, so it's an issue when we need to load more data),
- Pagination handling in bars requests,
- Cleaner error handling when communicating with Alpaca (with extension methods).